### PR TITLE
Fix genus spelling in sample inventory

### DIFF
--- a/data/sample_inventory.json
+++ b/data/sample_inventory.json
@@ -34,7 +34,7 @@
     "Class": 1,
     "Order": "Carcharhiniformes",
     "Family": "Carcharhinidae",
-    "Genus": "Carcharinus",
+    "Genus": "Carcharhinus",
     "Species": "albimarginatus",
     "Common Name": "Silvertip Shark",
     "Location": "Clipperton",


### PR DESCRIPTION
## Summary
- correct genus for the Silvertip Shark entry in `sample_inventory.json`

## Testing
- `python -m json.tool data/sample_inventory.json`

------
https://chatgpt.com/codex/tasks/task_e_68504c74a6ac832a8f48d39d0db9e618