### PR TITLE
Add Jest tests for database module

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -265,3 +265,8 @@ const Database = (function() {
         saveData
     };
 })();
+
+// Allow Node.js environments to import the Database module for testing
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Database;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ucla-zooarch",
+  "version": "1.0.0",
+  "description": "A web-based inventory management system for zoological and archaeological laboratory specimens. This application provides a user-friendly interface to browse, search, update, and analyze specimen collections.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const vm = require('vm');
+
+describe('Database module', () => {
+  let Database;
+  let localStorageMock;
+
+  const loadModule = () => {
+    const code = require('fs').readFileSync(path.join(__dirname, '../js/database.js'), 'utf8');
+    const context = { console, localStorage: localStorageMock, setTimeout, clearTimeout, clearInterval, setInterval, FileReader: function(){} };
+    vm.createContext(context);
+    vm.runInContext(code, context);
+    return context.Database;
+  };
+
+  beforeEach(() => {
+    localStorageMock = (() => {
+      let store = {};
+      return {
+        getItem: key => store[key],
+        setItem: (key, value) => { store[key] = String(value); },
+        removeItem: key => { delete store[key]; },
+        clear: () => { store = {}; }
+      };
+    })();
+    Database = loadModule();
+  });
+
+  test('addItem adds new items and prevents duplicates', () => {
+    const item = { 'Catalog #': '123', Order: '', Family: '', Genus: '', Species: '', 'Common Name': '', Location: '', Country: '', 'How collected': '', 'Date collected': '' };
+    expect(Database.addItem(item)).toBe(true);
+    expect(Database.getItemByCatalog('123')).toEqual(item);
+    expect(Database.addItem(item)).toBe(false);
+  });
+
+  test('getItemByCatalog trims catalog numbers', () => {
+    const item = { 'Catalog #': 'abc', Order: '', Family: '', Genus: '', Species: '', 'Common Name': '', Location: '', Country: '', 'How collected': '', 'Date collected': '' };
+    Database.addItem(item);
+    expect(Database.getItemByCatalog(' abc ')).toEqual(item);
+  });
+
+  test('hasIncompleteFields identifies required fields', () => {
+    const complete = { Order: 'A', Family: 'B', Genus: 'C', Species: 'D', 'Common Name': 'E', Location: 'F', Country: 'G', 'How collected': 'H', 'Date collected': 'I' };
+    const incomplete = { Order: 'A', Family: '', Genus: 'C' };
+    expect(Database.hasIncompleteFields(complete)).toBe(false);
+    expect(Database.hasIncompleteFields(incomplete)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `package.json` with Jest
- export database module for Node.js
- create initial database unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504fcfc2dc832a890e3c356537374c